### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   ],
   "dependencies": {
     "@essential-projects/event_aggregator_contracts": "feature~remove_old_datastore_implementation",
-    "@essential-projects/iam_contracts": "^3.0.0",
     "debug": "^2.6.1",
     "uuid": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "components for the internal messagebus",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -14,7 +14,7 @@
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
   "dependencies": {
-    "@essential-projects/event_aggregator_contracts": "feature~remove_old_datastore_implementation",
+    "@essential-projects/event_aggregator_contracts": "^3.0.0",
     "debug": "^2.6.1",
     "uuid": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
   "dependencies": {
-    "@essential-projects/core_contracts": "^2.0.0",
-    "@essential-projects/event_aggregator_contracts": "^2.0.0",
+    "@essential-projects/event_aggregator_contracts": "feature~remove_old_datastore_implementation",
+    "@essential-projects/iam_contracts": "^3.0.0",
     "debug": "^2.6.1",
     "uuid": "^3.0.1"
   },

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -84,7 +84,7 @@ export class EventAggregator implements IEventAggregator {
                            metadataOptions?: {[key: string]: any},
                           ): IEntityEvent {
 
-    const metadata = this._createEventMetadata(context, metadataOptions);
+    const metadata = this._createEventMetadata(metadataOptions);
 
     const message = {
       metadata: metadata,

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -1,5 +1,4 @@
 import {IEntityEvent, IEventAggregator, IEventMetadata, ISubscription} from '@essential-projects/event_aggregator_contracts';
-import {ExecutionContext} from '@essential-projects/iam_contracts';
 
 import * as debug from 'debug';
 import * as uuid from 'uuid';
@@ -82,7 +81,6 @@ export class EventAggregator implements IEventAggregator {
 
   public createEntityEvent(data: any,
                            source: any,
-                           context: ExecutionContext,
                            metadataOptions?: {[key: string]: any},
                           ): IEntityEvent {
 
@@ -97,11 +95,10 @@ export class EventAggregator implements IEventAggregator {
     return message;
   }
 
-  private _createEventMetadata(context: ExecutionContext, metadataOptions?: { [key: string]: any }): IEventMetadata {
+  private _createEventMetadata(metadataOptions?: { [key: string]: any }): IEventMetadata {
 
     const metadata: IEventMetadata = {
       id: uuid.v4(),
-      context: context,
       options: metadataOptions,
     };
 

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -1,5 +1,6 @@
-import {ExecutionContext, IEntity} from '@essential-projects/core_contracts';
 import {IEntityEvent, IEventAggregator, IEventMetadata, ISubscription} from '@essential-projects/event_aggregator_contracts';
+import {ExecutionContext} from '@essential-projects/iam_contracts';
+
 import * as debug from 'debug';
 import * as uuid from 'uuid';
 
@@ -80,7 +81,7 @@ export class EventAggregator implements IEventAggregator {
   }
 
   public createEntityEvent(data: any,
-                           source: IEntity,
+                           source: any,
                            context: ExecutionContext,
                            metadataOptions?: {[key: string]: any},
                           ): IEntityEvent {


### PR DESCRIPTION
## What did you change?

Removes all references to `core_contracts`, aswell as the need for an execution context, when creating messages.

## How can others test the changes?

Use the `createEntityEvent` method to create a message to be used with the event aggregator. 
Everything else works as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
