### PR TITLE
♻️ Refactor event aggregator

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.2",
-    "@essential-projects/event_aggregator_contracts": "~3.1.0",
+    "@essential-projects/event_aggregator_contracts": "feature~refactor_event_aggregator",
     "loggerhythm": "^3.0.3",
     "uuid": "~3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@essential-projects/errors_ts": "~1.4.2",
-    "@essential-projects/event_aggregator_contracts": "feature~refactor_event_aggregator",
+    "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "loggerhythm": "^3.0.3",
     "uuid": "~3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "components for the internal messagebus",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "Sebastian Meier <sebastian.meier@5minds.de>"
   ],
   "dependencies": {
+    "@essential-projects/errors_ts": "~1.4.2",
     "@essential-projects/event_aggregator_contracts": "~3.1.0",
-    "debug": "4.1.0",
-    "uuid": "3.3.2"
+    "loggerhythm": "^3.0.3",
+    "uuid": "~3.3.2"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -1,6 +1,7 @@
 import {Logger} from 'loggerhythm';
 import * as uuid from 'uuid';
 
+import {BadRequestError} from '@essential-projects/errors_ts';
 import {EventReceivedCallback, IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 
 import {EventSubscriptionDictionary, IInternalSubscription, SubscriberCollection} from './internal_types';
@@ -49,7 +50,11 @@ export class EventAggregator implements IEventAggregator {
   private _createSubscription(event: string, callback: EventReceivedCallback, subscribeOnce: boolean): Subscription {
 
     if (!event) {
-      throw new Error('Event name is invalid.');
+      throw new BadRequestError('No event name provided for the subscription!');
+    }
+
+    if (!callback) {
+      throw new BadRequestError('No callback function provided for the subscription!');
     }
 
     const subscriptionId: string = uuid.v4();

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -1,145 +1,89 @@
-import {IEntityEvent, IEventAggregator, IEventMetadata, ISubscription} from '@essential-projects/event_aggregator_contracts';
-
-import * as debug from 'debug';
+import {Logger} from 'loggerhythm';
 import * as uuid from 'uuid';
 
-// tslint:disable:typedef
-// tslint:disable:max-classes-per-file
-const debugError = debug('event_aggregator:error');
+import {EventReceivedCallback, IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
+
+import {EventSubscriptionDictionary, IInternalSubscription, SubscriberCollection} from './internal_types';
+
+const logger: Logger = Logger.createLogger('essential-projects:event_aggregator');
 
 export class EventAggregator implements IEventAggregator {
 
-  private eventLookup = {};
-  private messageHandlers = [];
+  private eventSubscriptionDictionary: EventSubscriptionDictionary = {};
 
-  public publish(event: string | any, data?: any): void {
-    let subscribers;
-    let i;
+  public subscribe(eventName: string, callback: EventReceivedCallback): Subscription {
+    return this._createSubscription(eventName, callback, false);
+  }
+
+  public subscribeOnce(eventName: string, callback: EventReceivedCallback): Subscription {
+    return this._createSubscription(eventName, callback, true);
+  }
+
+  public publish(eventName: string, payload?: any): void {
+
+    const noSubscribersForEventExist: boolean =
+      !this.eventSubscriptionDictionary[eventName] ||
+      Object.keys(!this.eventSubscriptionDictionary[eventName]).length === 0;
+    if (noSubscribersForEventExist) {
+      return;
+    }
+
+    const eventSubscriptions: SubscriberCollection = this.eventSubscriptionDictionary[eventName];
+
+    const subscriptionIds: Array<string> = Object.keys(eventSubscriptions);
+
+    for (const subscribtionId of subscriptionIds) {
+      const subscription: IInternalSubscription = eventSubscriptions[subscribtionId];
+      invokeEventCallback(eventName, payload, subscription.callback);
+
+      if (subscription.subscribeOnce) {
+        delete this.eventSubscriptionDictionary[eventName][subscribtionId];
+      }
+    }
+  }
+
+  public unsubscribe(subscription: Subscription): void {
+    delete this.eventSubscriptionDictionary[subscription.eventName][subscription.id];
+  }
+
+  private _createSubscription(event: string, callback: EventReceivedCallback, subscribeOnce: boolean): Subscription {
 
     if (!event) {
-      throw new Error('event was invalid.');
+      throw new Error('Event name is invalid.');
     }
 
-    if (typeof event === 'string') {
-      subscribers = this.eventLookup[event];
-      if (subscribers) {
-        subscribers = subscribers.slice();
-        i = subscribers.length;
+    const subscriptionId: string = uuid.v4();
+    const newSubscription: Subscription = new Subscription(subscriptionId, event, subscribeOnce);
 
-        while (i--) {
-          invokeCallback(subscribers[i], data, event);
-        }
-      }
-    } else {
-      subscribers = this.messageHandlers.slice();
-      i = subscribers.length;
-
-      while (i--) {
-        invokeHandler(subscribers[i], event);
-      }
-    }
-  }
-
-  public subscribe(event: string | Function, callback: Function): ISubscription {
-    let handler;
-    let subscribers;
-
-    if (!event) {
-      throw new Error('Event channel/type was invalid.');
+    const eventIsNotYetRegistered: boolean = !this.eventSubscriptionDictionary[event];
+    if (eventIsNotYetRegistered) {
+      this.eventSubscriptionDictionary[event] = {};
     }
 
-    if (typeof event === 'string') {
-      handler = callback;
-      subscribers = this.eventLookup[event] || (this.eventLookup[event] = []);
-    } else {
-      handler = new Handler(event, callback);
-      subscribers = this.messageHandlers;
-    }
-
-    subscribers.push(handler);
-
-    return {
-      dispose() {
-        const index = subscribers.indexOf(handler);
-        if (index !== -1) {
-          subscribers.splice(index, 1);
-        }
-      },
-    };
-  }
-
-  public subscribeOnce(event: string | Function, callback: Function): ISubscription {
-
-    const subscription = this.subscribe(event, (a, b) => {
-      subscription.dispose();
-
-      return callback(a, b);
-    });
-
-    return subscription;
-  }
-
-  public createEntityEvent(data: any,
-                           source: any,
-                           metadataOptions?: {[key: string]: any},
-                          ): IEntityEvent {
-
-    const metadata = this._createEventMetadata(metadataOptions);
-
-    const message = {
-      metadata: metadata,
-      data: data,
-      source: source,
+    this.eventSubscriptionDictionary[event][subscriptionId] = {
+      subscribeOnce: subscribeOnce,
+      callback: callback,
     };
 
-    return message;
-  }
-
-  private _createEventMetadata(metadataOptions?: { [key: string]: any }): IEventMetadata {
-
-    const metadata: IEventMetadata = {
-      id: uuid.v4(),
-      options: metadataOptions,
-    };
-
-    return metadata;
+    return newSubscription;
   }
 }
 
-function invokeCallback(callback, data, event) {
+/**
+ * Triggers the given callback directly with the next process tick.
+ * This makes event publishing as instantaneously as it can be with NodeJs.
+ *
+ * @param eventName    The event name.
+ * @param eventPayload The event payload.
+ * @param callback     The function to trigger.
+ */
+function invokeEventCallback(eventName: string, eventPayload: any, callback: Function): void {
   process.nextTick(() => {
     try {
-      callback(data, event);
+      callback(eventPayload, eventName);
     } catch (e) {
-      debugError(e);
+      logger.error(e);
     }
   });
 
-}
-
-function invokeHandler(handler, data) {
-  process.nextTick(() => {
-    try {
-      handler.handle(data);
-    } catch (e) {
-      debugError(e);
-    }
-  });
-}
-
-class Handler {
-
-  private messageType;
-  private callback;
-
-  constructor(messageType, callback) {
-    this.messageType = messageType;
-    this.callback = callback;
-  }
-
-  public handle(message) {
-    if (message instanceof this.messageType) {
-      this.callback.call(null, message);
-    }
-  }
 }

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -90,5 +90,4 @@ function invokeEventCallback(eventName: string, eventPayload: any, callback: Fun
       logger.error(e);
     }
   });
-
 }

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -65,7 +65,7 @@ export class EventAggregator implements IEventAggregator {
       this.eventSubscriptionDictionary[event] = {};
     }
 
-    this.eventSubscriptionDictionary[event][subscriptionId] = {
+    this.eventSubscriptionDictionary[event][subscriptionId] = <IInternalSubscription> {
       subscribeOnce: subscribeOnce,
       callback: callback,
     };

--- a/src/event_aggregator.ts
+++ b/src/event_aggregator.ts
@@ -24,7 +24,7 @@ export class EventAggregator implements IEventAggregator {
 
     const noSubscribersForEventExist: boolean =
       !this.eventSubscriptionDictionary[eventName] ||
-      Object.keys(!this.eventSubscriptionDictionary[eventName]).length === 0;
+      Object.keys(this.eventSubscriptionDictionary[eventName]).length === 0;
     if (noSubscribersForEventExist) {
       return;
     }

--- a/src/internal_types.ts
+++ b/src/internal_types.ts
@@ -1,0 +1,40 @@
+import {EventReceivedCallback} from '@essential-projects/event_aggregator_contracts';
+
+/**
+ * Internal type for grouping all EventSubscriptions by the event to which
+ * they have subscribed.
+ *
+ * Syntax looks like this:
+ * {
+ *   eventName1: {
+ *     subscriptionId1: {
+ *       subscribeOnce: true|false,
+ *       callback: [Function someFunction],
+ *     },
+ *     subscriptionId2: {
+ *       subscribeOnce: true|false,
+ *       callback: [Function someFunction],
+ *     },
+ *   }
+ *   eventName2: {
+ *     subscriptionId1: {
+ *       subscribeOnce: true|false,
+ *       callback: [Function someFunction],
+ *     },
+ *   }
+ * }
+ */
+export type EventSubscriptionDictionary = {[eventName: string]: SubscriberCollection};
+
+/**
+ * Internal type for storing a Subscription under a specified ID.
+ */
+export type SubscriberCollection = {[subscriberId: string]: IInternalSubscription};
+
+/**
+ * Internal type that describes a event subscription.
+ */
+export interface IInternalSubscription {
+  subscribeOnce: boolean;
+  callback: EventReceivedCallback;
+}

--- a/src/internal_types.ts
+++ b/src/internal_types.ts
@@ -27,12 +27,12 @@ import {EventReceivedCallback} from '@essential-projects/event_aggregator_contra
 export type EventSubscriptionDictionary = {[eventName: string]: SubscriberCollection};
 
 /**
- * Internal type for storing a Subscription under a specified ID.
+ * Internal type for grouping together multiple subscriptions for a specific event.
  */
 export type SubscriberCollection = {[subscriberId: string]: IInternalSubscription};
 
 /**
- * Internal type that describes a event subscription.
+ * Internal interface that describes a single subscription.
  */
 export interface IInternalSubscription {
   subscribeOnce: boolean;


### PR DESCRIPTION
**Changes:**

1. Use `~` type dependencies for non critical packages and devDependencies
2. Remove `createEntityEvent` function from the `EventAggregator`.
3. Replace the obese `subscription.dispose()` pattern with a new `unsubscribe` function on the `EventAggregator` itself.
    - Disposal now works with the following call: `eventAggregator.unsubscribe(subscriptionToDispose);`
4. Refactor the internal structure of the EventAggregator. Instead of some obese Array magic, event subscriptions are now stored in groups, named after the Event they subscribe to. 
    - Each Subscription now gets a unique ID assigned to it, by which can be retrieved and ultimately disposed.
    - See [here](https://github.com/essential-projects/event_aggregator/blob/de65fe5aad3ae1fed16ef591474300833932f7db/src/internal_types.ts#L8) for a description about the new internal storage
5. An internally stored EventSubscription now contains two Properties: 
    - callback: The callback to call for the subscription, when the corresponding event is received.
    - subscribeOnce: If set to `true`, the subscription will be destroyed, after the event has been received once.
6. Replace `debug` with `loggerhythm`.
7. Use types from `errors_ts` for error handling.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/184

PR: #3

## How can others test the changes?

Use the new EventAggregator to create and destroy EventSubscriptions and for publishing events.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
